### PR TITLE
fix: static versioning

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,8 +18,6 @@ builds:
       - darwin
       # The linter is not yet available for Windows.
       # - windows
-    ldflags:
-      - -s -w -X main.currentVersion={{.Version}} -X main.currentShortCommit={{.ShortCommit}} -X main.currentCommitDate={{.CommitDate}}
     mod_timestamp: "{{ .CommitTimestamp }}"
 archives:
   - id: godoclint

--- a/cmd/godoclint/main.go
+++ b/cmd/godoclint/main.go
@@ -10,13 +10,7 @@ import (
 	"github.com/godoc-lint/godoc-lint/pkg/check"
 	"github.com/godoc-lint/godoc-lint/pkg/config"
 	"github.com/godoc-lint/godoc-lint/pkg/inspect"
-)
-
-// There are intended to be populated at build time (via -ldflags option).
-var (
-	currentVersion     = "dev"
-	currentShortCommit = "0000000"
-	currentCommitDate  = "n/a"
+	"github.com/godoc-lint/godoc-lint/pkg/version"
 )
 
 func main() {
@@ -38,7 +32,7 @@ func main() {
 	analyzer := analysis.NewAnalyzer(baseDir, ocb, reg, inspector, exitFunc)
 
 	analyzer.GetAnalyzer().Flags.BoolFunc("V", "print version and exit", func(s string) error {
-		fmt.Printf("%s %s (%s)\n", currentVersion, currentShortCommit, currentCommitDate)
+		fmt.Println(version.Current)
 		os.Exit(0)
 		return nil
 	})

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,28 @@
+package version
+
+import "fmt"
+
+// Current represents the current version.
+var Current = Version{
+	Major:  0,
+	Minor:  2,
+	Patch:  0,
+	Suffix: "dev",
+}
+
+// Version represents module version (in semver format).
+type Version struct {
+	Major  uint
+	Minor  uint
+	Patch  uint
+	Suffix string
+}
+
+// String returns the string representation of the current instance.
+func (v Version) String() string {
+	suffix := ""
+	if v.Suffix != "" {
+		suffix = "-" + v.Suffix
+	}
+	return fmt.Sprintf("%d.%d.%d%s", v.Major, v.Minor, v.Patch, suffix)
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,35 @@
+package version_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/godoc-lint/godoc-lint/pkg/version"
+	"github.com/stretchr/testify/assert"
+)
+
+var _ fmt.Stringer = version.Version{}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    version.Version
+		expected string
+	}{{
+		name:     "zero",
+		expected: "0.0.0",
+	}, {
+		name:     "no suffix",
+		value:    version.Version{1, 2, 3, ""},
+		expected: "1.2.3",
+	}, {
+		name:     "all",
+		value:    version.Version{1, 2, 3, "foo"},
+		expected: "1.2.3-foo",
+	},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.value.String(), "case: %q", tt.name)
+	}
+}


### PR DESCRIPTION
This PR adds hard-coded version info, within the `pkg/version` package. The reason for this change is to print the right version when users install the linter via `go install`.