### PR TITLE
refactor: simplify pass file iterations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/godoc-lint/godoc-lint
 
-go 1.22.3
+go 1.24.1
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pkg/check/max_len/max_len.go
+++ b/pkg/check/max_len/max_len.go
@@ -34,25 +34,7 @@ func (r *MaxLenChecker) Apply(actx *model.AnalysisContext) error {
 
 	docs := make(map[*model.CommentGroup]struct{}, 10*len(actx.InspectorResult.Files))
 
-	for _, f := range actx.Pass.Files {
-		if !util.IsFileApplicable(actx, f) {
-			continue
-		}
-
-		ft := util.GetPassFileToken(f, actx.Pass)
-		if ft == nil {
-			continue
-		}
-
-		if !includeTests && strings.HasSuffix(ft.Name(), "_test.go") {
-			continue
-		}
-
-		ir := actx.InspectorResult.Files[f]
-		if ir == nil || ir.DisabledRules.All || ir.DisabledRules.Rules.Has(MaxLenRule) {
-			continue
-		}
-
+	for _, ir := range util.AnalysisApplicableFiles(actx, includeTests, model.RuleSet{}.Add(MaxLenRule)) {
 		if ir.PackageDoc != nil {
 			docs[ir.PackageDoc] = struct{}{}
 		}

--- a/pkg/check/no_unused_link/no_unused_link.go
+++ b/pkg/check/no_unused_link/no_unused_link.go
@@ -1,8 +1,6 @@
 package no_unused_link
 
 import (
-	"strings"
-
 	"github.com/godoc-lint/godoc-lint/pkg/model"
 	"github.com/godoc-lint/godoc-lint/pkg/util"
 )
@@ -31,25 +29,7 @@ func (r *NoUnusedLinkChecker) Apply(actx *model.AnalysisContext) error {
 
 	docs := make(map[*model.CommentGroup]struct{}, 10*len(actx.InspectorResult.Files))
 
-	for _, f := range actx.Pass.Files {
-		if !util.IsFileApplicable(actx, f) {
-			continue
-		}
-
-		ft := util.GetPassFileToken(f, actx.Pass)
-		if ft == nil {
-			continue
-		}
-
-		if !includeTests && strings.HasSuffix(ft.Name(), "_test.go") {
-			continue
-		}
-
-		ir := actx.InspectorResult.Files[f]
-		if ir == nil || ir.DisabledRules.All || ir.DisabledRules.Rules.Has(NoUnusedLinkRule) {
-			continue
-		}
-
+	for _, ir := range util.AnalysisApplicableFiles(actx, includeTests, model.RuleSet{}.Add(NoUnusedLinkRule)) {
 		if ir.PackageDoc != nil {
 			docs[ir.PackageDoc] = struct{}{}
 		}

--- a/pkg/check/pkg_doc/pkg_doc.go
+++ b/pkg/check/pkg_doc/pkg_doc.go
@@ -49,25 +49,7 @@ func checkPkgDocRule(actx *model.AnalysisContext) {
 	includeTests := actx.Config.GetRuleOptions().PkgDocIncludeTests
 	startWith := strings.TrimSpace(actx.Config.GetRuleOptions().PkgDocStartWith)
 
-	for _, f := range actx.Pass.Files {
-		if !util.IsFileApplicable(actx, f) {
-			continue
-		}
-
-		ft := util.GetPassFileToken(f, actx.Pass)
-		if ft == nil {
-			continue
-		}
-
-		if !includeTests && strings.HasSuffix(ft.Name(), "_test.go") {
-			continue
-		}
-
-		ir := actx.InspectorResult.Files[f]
-		if ir == nil || ir.DisabledRules.All || ir.DisabledRules.Rules.Has(PkgDocRule) {
-			continue
-		}
-
+	for f, ir := range util.AnalysisApplicableFiles(actx, includeTests, model.RuleSet{}.Add(PkgDocRule)) {
 		if ir.PackageDoc == nil {
 			continue
 		}
@@ -106,25 +88,7 @@ func checkSinglePkgDocRule(actx *model.AnalysisContext) {
 
 	documentedPkgs := make(map[string][]*ast.File, 2)
 
-	for _, f := range actx.Pass.Files {
-		if !util.IsFileApplicable(actx, f) {
-			continue
-		}
-
-		ft := util.GetPassFileToken(f, actx.Pass)
-		if ft == nil {
-			continue
-		}
-
-		if !includeTests && strings.HasSuffix(ft.Name(), "_test.go") {
-			continue
-		}
-
-		ir := actx.InspectorResult.Files[f]
-		if ir == nil || ir.DisabledRules.All || ir.DisabledRules.Rules.Has(SinglePkgDocRule) {
-			continue
-		}
-
+	for f, ir := range util.AnalysisApplicableFiles(actx, includeTests, model.RuleSet{}.Add(SinglePkgDocRule)) {
 		if ir.PackageDoc == nil || ir.PackageDoc.Text == "" {
 			continue
 		}
@@ -160,25 +124,7 @@ func checkRequirePkgDocRule(actx *model.AnalysisContext) {
 
 	pkgFiles := make(map[string][]*ast.File, 2)
 
-	for _, f := range actx.Pass.Files {
-		if !util.IsFileApplicable(actx, f) {
-			continue
-		}
-
-		ft := util.GetPassFileToken(f, actx.Pass)
-		if ft == nil {
-			continue
-		}
-
-		if !includeTests && strings.HasSuffix(ft.Name(), "_test.go") {
-			continue
-		}
-
-		ir := actx.InspectorResult.Files[f]
-		if ir == nil || ir.DisabledRules.All || ir.DisabledRules.Rules.Has(RequirePkgDocRule) {
-			continue
-		}
-
+	for f := range util.AnalysisApplicableFiles(actx, includeTests, model.RuleSet{}.Add(RequirePkgDocRule)) {
 		pkg := f.Name.Name
 		if _, ok := pkgFiles[pkg]; !ok {
 			pkgFiles[pkg] = make([]*ast.File, 0, len(actx.Pass.Files))

--- a/pkg/check/require_doc/require_doc.go
+++ b/pkg/check/require_doc/require_doc.go
@@ -2,7 +2,6 @@ package require_doc
 
 import (
 	"go/ast"
-	"strings"
 
 	"golang.org/x/tools/go/analysis"
 
@@ -38,25 +37,7 @@ func (r *RequireDocChecker) Apply(actx *model.AnalysisContext) error {
 		return nil
 	}
 
-	for _, f := range actx.Pass.Files {
-		if !util.IsFileApplicable(actx, f) {
-			continue
-		}
-
-		ft := util.GetPassFileToken(f, actx.Pass)
-		if ft == nil {
-			continue
-		}
-
-		if !includeTests && strings.HasSuffix(ft.Name(), "_test.go") {
-			continue
-		}
-
-		ir := actx.InspectorResult.Files[f]
-		if ir == nil || ir.DisabledRules.All || ir.DisabledRules.Rules.Has(RequireDocRule) {
-			continue
-		}
-
+	for _, ir := range util.AnalysisApplicableFiles(actx, includeTests, model.RuleSet{}.Add(RequireDocRule)) {
 		for _, decl := range ir.SymbolDecl {
 			isExported := ast.IsExported(decl.Name)
 			if isExported && !requirePublic || !isExported && !requirePrivate {

--- a/pkg/check/start_with_name/start_with_name.go
+++ b/pkg/check/start_with_name/start_with_name.go
@@ -40,25 +40,7 @@ func (r *StartWithNameChecker) Apply(actx *model.AnalysisContext) error {
 		return err
 	}
 
-	for _, f := range actx.Pass.Files {
-		if !util.IsFileApplicable(actx, f) {
-			continue
-		}
-
-		ft := util.GetPassFileToken(f, actx.Pass)
-		if ft == nil {
-			continue
-		}
-
-		if !includeTests && strings.HasSuffix(ft.Name(), "_test.go") {
-			continue
-		}
-
-		ir := actx.InspectorResult.Files[f]
-		if ir == nil || ir.DisabledRules.All || ir.DisabledRules.Rules.Has(StartWithNameRule) {
-			continue
-		}
-
+	for _, ir := range util.AnalysisApplicableFiles(actx, includeTests, model.RuleSet{}.Add(StartWithNameRule)) {
 		for _, decl := range ir.SymbolDecl {
 			if decl.Kind == model.SymbolDeclKindBad {
 				continue

--- a/pkg/util/ast.go
+++ b/pkg/util/ast.go
@@ -24,27 +24,20 @@ func GetPassFileToken(f *ast.File, pass *analysis.Pass) *token.File {
 	return ft
 }
 
-// IsFileApplicable is a helper function to determine if the given AST file
-// should be included in analysis.
-func IsFileApplicable(actx *model.AnalysisContext, f *ast.File) bool {
-	if actx.InspectorResult == nil || actx.InspectorResult.Files[f] == nil {
-		return false
-	}
-	ft := GetPassFileToken(f, actx.Pass)
-	if ft == nil {
-		return false
-	}
-	return actx.Config.IsPathApplicable(ft.Name())
-}
-
 // AnalysisApplicableFiles returns an iterator looping over files that are ready
 // to be analyzed.
 //
 // The yield-ed arguments are never nil.
 func AnalysisApplicableFiles(actx *model.AnalysisContext, includeTests bool, ruleSet model.RuleSet) iter.Seq2[*ast.File, *model.FileInspection] {
 	return func(yield func(*ast.File, *model.FileInspection) bool) {
+		if actx.InspectorResult == nil {
+			return
+		}
+
 		for _, f := range actx.Pass.Files {
-			if !IsFileApplicable(actx, f) {
+			ir := actx.InspectorResult.Files[f]
+
+			if ir == nil {
 				continue
 			}
 
@@ -53,12 +46,15 @@ func AnalysisApplicableFiles(actx *model.AnalysisContext, includeTests bool, rul
 				continue
 			}
 
+			if !actx.Config.IsPathApplicable(ft.Name()) {
+				continue
+			}
+
 			if !includeTests && strings.HasSuffix(ft.Name(), "_test.go") {
 				continue
 			}
 
-			ir := actx.InspectorResult.Files[f]
-			if ir == nil || ir.DisabledRules.All || ir.DisabledRules.Rules.IsSupersetOf(ruleSet) {
+			if ir.DisabledRules.All || ir.DisabledRules.Rules.IsSupersetOf(ruleSet) {
 				continue
 			}
 


### PR DESCRIPTION
This PR removes duplicate codes used to iterate over pass files.

This also bumps the Go version to v1.24.1.