### PR TITLE
fix: ignore command packages when applying `pkg-doc` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ package foo
 
 The "Package" word can be configured to any other value via the `pkg-doc/start-with` option. Test files are skipped by default. To enable the rule for them, the `pkg-doc/include-tests` option should be set to `true`.
 
+> [!NOTE]
+> As of [*Go Doc Comments*][godoc-cmd-ref], command packages (i.e., packages named `main`) are exceptions to this rule. So, Godoc-Lint ignores them and their test packages (i.e., `main_test`) by default.
+
+[godoc-cmd-ref]: https://go.dev/doc/comment#cmd
+
 ### `single-pkg-doc`
 
 Technically, every Go file in a package can have a godoc above the `package` statement. This rule enforces only one godoc, if any, for any package. Test files are skipped by default. To enable the rule for them, the `single-pkg-doc/include-tests` option should be set to `true`.

--- a/pkg/check/pkg_doc/pkg_doc.go
+++ b/pkg/check/pkg_doc/pkg_doc.go
@@ -41,6 +41,9 @@ func (r *PkgDocChecker) Apply(actx *model.AnalysisContext) error {
 	return nil
 }
 
+const commandPkgName = "main"
+const commandTestPkgName = "main_test"
+
 func checkPkgDocRule(actx *model.AnalysisContext) {
 	if !actx.Config.IsAnyRuleApplicable(model.RuleSet{}.Add(PkgDocRule)) {
 		return
@@ -55,6 +58,16 @@ func checkPkgDocRule(actx *model.AnalysisContext) {
 		}
 
 		if ir.PackageDoc.DisabledRules.All || ir.PackageDoc.DisabledRules.Rules.Has(PkgDocRule) {
+			continue
+		}
+
+		if f.Name.Name == commandPkgName || f.Name.Name == commandTestPkgName {
+			// Skip command packages, as they are not required to start with
+			// "Package main" or "Package main_test".
+			//
+			// See for more details:
+			//   - https://github.com/godoc-lint/godoc-lint/issues/10
+			//   - https://go.dev/doc/comment#cmd
 			continue
 		}
 

--- a/testdata/rule/pkg_doc/command_pkg/.godoc-lint.yaml
+++ b/testdata/rule/pkg_doc/command_pkg/.godoc-lint.yaml
@@ -1,0 +1,5 @@
+enable:
+  - pkg-doc
+options:
+  pkg-doc/start-with: Package
+  pkg-doc/include-tests: true

--- a/testdata/rule/pkg_doc/command_pkg/good.go
+++ b/testdata/rule/pkg_doc/command_pkg/good.go
@@ -1,0 +1,11 @@
+// some header
+
+// Foo is a fake command.
+//
+// This test is to ensure that the godoc for command packages (i.e. `main`
+// packages) are not enforced to begin with "Package main".
+//
+// See for more details:
+//   - https://github.com/godoc-lint/godoc-lint/issues/10
+//   - https://go.dev/doc/comment#cmd
+package main

--- a/testdata/rule/pkg_doc/command_pkg/good_pkg_test.go
+++ b/testdata/rule/pkg_doc/command_pkg/good_pkg_test.go
@@ -1,0 +1,11 @@
+// some header
+
+// Foo is a fake command.
+//
+// This test is to ensure that the godoc for command packages (i.e. `main`
+// packages) are not enforced to begin with "Package main".
+//
+// See for more details:
+//   - https://github.com/godoc-lint/godoc-lint/issues/10
+//   - https://go.dev/doc/comment#cmd
+package main_test

--- a/testdata/rule/pkg_doc/command_pkg/good_test.go
+++ b/testdata/rule/pkg_doc/command_pkg/good_test.go
@@ -1,0 +1,11 @@
+// some header
+
+// Foo is a fake command.
+//
+// This test is to ensure that the godoc for command packages (i.e. `main`
+// packages) are not enforced to begin with "Package main".
+//
+// See for more details:
+//   - https://github.com/godoc-lint/godoc-lint/issues/10
+//   - https://go.dev/doc/comment#cmd
+package main


### PR DESCRIPTION
Fixes #10