### PR TITLE
fix: ignore godocs including `// Deprecated:` marker

### DIFF
--- a/pkg/check/shared/deprecated.go
+++ b/pkg/check/shared/deprecated.go
@@ -15,7 +15,10 @@ func HasDeprecatedParagraph(blocks []comment.Block) bool {
 		if !ok {
 			continue
 		}
-		if strings.HasPrefix(string(text), "Deprecated:") {
+
+		// Only an exact match (casing and the trailing whitespace) is considered
+		// a valid deprecation marker.
+		if strings.HasPrefix(string(text), "Deprecated: ") {
 			return true
 		}
 	}

--- a/pkg/check/shared/deprecated.go
+++ b/pkg/check/shared/deprecated.go
@@ -1,0 +1,23 @@
+package shared
+
+import (
+	"go/doc/comment"
+	"strings"
+)
+
+func HasDeprecatedParagraph(blocks []comment.Block) bool {
+	for _, block := range blocks {
+		par, ok := block.(*comment.Paragraph)
+		if !ok || len(par.Text) == 0 {
+			continue
+		}
+		text, ok := (par.Text[0]).(comment.Plain)
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(string(text), "Deprecated:") {
+			return true
+		}
+	}
+	return false
+}

--- a/testdata/rule/pkg_doc/with_deprecation/.godoc-lint.yaml
+++ b/testdata/rule/pkg_doc/with_deprecation/.godoc-lint.yaml
@@ -1,0 +1,5 @@
+enable:
+  - pkg-doc
+options:
+  pkg-doc/start-with: Package
+  pkg-doc/include-tests: true

--- a/testdata/rule/pkg_doc/with_deprecation/good.go
+++ b/testdata/rule/pkg_doc/with_deprecation/good.go
@@ -1,6 +1,6 @@
 // some header
 
-// Deprecated: with whitespace
+// Deprecated: valid deprecation
 //
 // bad godoc
 package with_deprecation

--- a/testdata/rule/pkg_doc/with_deprecation/good.go
+++ b/testdata/rule/pkg_doc/with_deprecation/good.go
@@ -1,0 +1,6 @@
+// some header
+
+// Deprecated: with whitespace
+//
+// bad godoc
+package with_deprecation

--- a/testdata/rule/pkg_doc/with_deprecation/good_pkg_test.go
+++ b/testdata/rule/pkg_doc/with_deprecation/good_pkg_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// Deprecated:with whitespace
+package with_deprecation_test

--- a/testdata/rule/pkg_doc/with_deprecation/good_pkg_test.go
+++ b/testdata/rule/pkg_doc/with_deprecation/good_pkg_test.go
@@ -1,4 +1,4 @@
 // some header
 
-// Deprecated:with whitespace
+// Deprecated: valid deprecation
 package with_deprecation_test

--- a/testdata/rule/pkg_doc/with_deprecation/good_test.go
+++ b/testdata/rule/pkg_doc/with_deprecation/good_test.go
@@ -1,6 +1,6 @@
 // some header
 
-// bad godoc
+// bad godoc but okay due to the valid deprecation marker
 //
-// Deprecated:with whitespace
+// Deprecated: valid deprecation
 package with_deprecation

--- a/testdata/rule/pkg_doc/with_deprecation/good_test.go
+++ b/testdata/rule/pkg_doc/with_deprecation/good_test.go
@@ -1,0 +1,6 @@
+// some header
+
+// bad godoc
+//
+// Deprecated:with whitespace
+package with_deprecation

--- a/testdata/rule/pkg_doc/with_deprecation/missing.go
+++ b/testdata/rule/pkg_doc/with_deprecation/missing.go
@@ -1,0 +1,6 @@
+// some header
+
+// Deprecated:invalid deprecation // want `package godoc should start with "Package with_deprecation "`
+//
+// since the deprecation marker is not in valid format, the rule should complain.
+package with_deprecation

--- a/testdata/rule/pkg_doc/with_deprecation/missing_pkg_test.go
+++ b/testdata/rule/pkg_doc/with_deprecation/missing_pkg_test.go
@@ -1,0 +1,6 @@
+// some header
+
+// DEPRECATED:invalid deprecation // want `package godoc should start with "Package with_deprecation_test "`
+//
+// since the deprecation marker is not in valid format, the rule should complain
+package with_deprecation_test

--- a/testdata/rule/pkg_doc/with_deprecation/missing_test.go
+++ b/testdata/rule/pkg_doc/with_deprecation/missing_test.go
@@ -1,0 +1,6 @@
+// some header
+
+// DEPRECATED: invalid deprecation // want `package godoc should start with "Package with_deprecation "`
+//
+// since the deprecation marker is not in valid format, the rule should complain
+package with_deprecation

--- a/testdata/rule/start_with_name/strict/good.go
+++ b/testdata/rule/start_with_name/strict/good.go
@@ -1,5 +1,9 @@
 package strict
 
+// (NG: no godoc)
+
+const SingleSingleFooNG = 0
+
 // SingleSingleFoo has a godoc.
 const SingleSingleFoo = 0
 

--- a/testdata/rule/start_with_name/with_deprecation/.godoc-lint.yaml
+++ b/testdata/rule/start_with_name/with_deprecation/.godoc-lint.yaml
@@ -1,0 +1,6 @@
+enable:
+  - start-with-name
+options:
+  start-with-name/include-tests: false
+  start-with-name/include-unexported: true
+  start-with-name/pattern: ""

--- a/testdata/rule/start_with_name/with_deprecation/good.go
+++ b/testdata/rule/start_with_name/with_deprecation/good.go
@@ -2,74 +2,80 @@ package strict
 
 // (BG: bad godoc)
 
-// Here a number of combinations of godocs and deprecations are tested.
+// Here, combinations of godocs and deprecations are tested on various declaration kinds.
 
-// Deprecated: with whitespace
-//
-// godoc
+// Deprecated: valid deprecation
 const SingleSingleFooBG = 0
 
 const (
-	// Deprecated:with no whitespace
+	// Deprecated: valid deprecation
 	//
-	// godoc
+	// bad godoc but okay due to the valid deprecation marker
 	MultiSingleFooBG = 0
 )
 
-// Deprecated: with whitespace
+// bad godoc but okay due to the valid deprecation marker
 //
-// Deprecated:with no whitespace
-//
-// godoc
+// Deprecated: valid deprecation
 const SingleSingleFooVarBG = 0
 
 var (
-	// Deprecated: with whitespace
+	// Deprecated: valid deprecation
 	//
-	// godoc
+	// bad godoc but okay due to the valid deprecation marker
 	//
-	// Deprecated:with no whitespace
+	// Deprecated: valid deprecation
 	MultiSingleFooVarBG = 0
 )
 
-// Deprecated:with no whitespace
+// bad godoc but okay due to the valid deprecation marker
 //
-// godoc
+// Deprecated: valid deprecation
 //
-// Deprecated: with whitespace
+// Deprecated: valid deprecation
 type TSingleFooBG int
 
 type (
-	// godoc
+	// Deprecated: valid deprecation
 	//
-	// Deprecated: with whitespace
+	// Deprecated: valid deprecation
+	//
+	// bad godoc but okay due to the valid deprecation marker
 	TMultiFooBG int
 
-	// godoc
+	// Deprecated: valid deprecation
 	//
-	// Deprecated:with no whitespace
+	// Deprecated:invalid deprecation
+	//
+	// bad godoc but okay due to the valid deprecation marker
 	TMultiBarBG int
 )
 
-// Deprecated: with whitespace
+// Deprecated:invalid deprecation
 //
-// Deprecated:with no whitespace
+// bad godoc but okay due to the valid deprecation marker
+//
+// Deprecated: valid deprecation
 func FooFuncBG() {}
 
-// Deprecated: with whitespace
+// Deprecated:invalid deprecation
 //
-// Deprecated:with no whitespace
+// Deprecated:invalid deprecation
 //
-// Deprecated: with whitespace
+// bad godoc but okay due to the valid deprecation marker
 //
-// godoc
+// Deprecated: valid deprecation
+//
+// Deprecated:invalid deprecation
 type TFooBG int
 
-// godoc
+// Deprecated:invalid deprecation
 //
-// Deprecated: with whitespace
+// Deprecated:invalid deprecation
 //
-// Deprecated:with no whitespace
+// bad godoc but okay due to the valid deprecation marker
 //
-// Deprecated: with whitespace
+// Deprecated:invalid deprecation
+//
+// Deprecated: valid deprecation
 func (*TFooBG) FooFuncBG() {}

--- a/testdata/rule/start_with_name/with_deprecation/good.go
+++ b/testdata/rule/start_with_name/with_deprecation/good.go
@@ -1,0 +1,75 @@
+package strict
+
+// (BG: bad godoc)
+
+// Here a number of combinations of godocs and deprecations are tested.
+
+// Deprecated: with whitespace
+//
+// godoc
+const SingleSingleFooBG = 0
+
+const (
+	// Deprecated:with no whitespace
+	//
+	// godoc
+	MultiSingleFooBG = 0
+)
+
+// Deprecated: with whitespace
+//
+// Deprecated:with no whitespace
+//
+// godoc
+const SingleSingleFooVarBG = 0
+
+var (
+	// Deprecated: with whitespace
+	//
+	// godoc
+	//
+	// Deprecated:with no whitespace
+	MultiSingleFooVarBG = 0
+)
+
+// Deprecated:with no whitespace
+//
+// godoc
+//
+// Deprecated: with whitespace
+type TSingleFooBG int
+
+type (
+	// godoc
+	//
+	// Deprecated: with whitespace
+	TMultiFooBG int
+
+	// godoc
+	//
+	// Deprecated:with no whitespace
+	TMultiBarBG int
+)
+
+// Deprecated: with whitespace
+//
+// Deprecated:with no whitespace
+func FooFuncBG() {}
+
+// Deprecated: with whitespace
+//
+// Deprecated:with no whitespace
+//
+// Deprecated: with whitespace
+//
+// godoc
+type TFooBG int
+
+// godoc
+//
+// Deprecated: with whitespace
+//
+// Deprecated:with no whitespace
+//
+// Deprecated: with whitespace
+func (*TFooBG) FooFuncBG() {}

--- a/testdata/rule/start_with_name/with_deprecation/missing.go
+++ b/testdata/rule/start_with_name/with_deprecation/missing.go
@@ -1,0 +1,72 @@
+package strict
+
+// (BGI: bad godoc with invalid deprecation)
+
+// Here, combinations of godocs and deprecations are tested on various declaration kinds.
+
+// Deprecated:invalid deprecation // want `godoc should start with symbol name \("SingleSingleFooBGI"\)`
+const SingleSingleFooBGI = 0
+
+const (
+	// Deprecated:invalid deprecation // want `godoc should start with symbol name \("MultiSingleFooBGI"\)`
+	//
+	// bad godoc
+	MultiSingleFooBGI = 0
+)
+
+// bad godoc // want `godoc should start with symbol name \("SingleSingleFooVarBGI"\)`
+//
+// Deprecated:invalid deprecation
+const SingleSingleFooVarBGI = 0
+
+var (
+	// Deprecated:invalid deprecation // want `godoc should start with symbol name \("MultiSingleFooVarBGI"\)`
+	//
+	// bad godoc
+	//
+	// Deprecated:invalid deprecation
+	MultiSingleFooVarBGI = 0
+)
+
+// bad godoc // want `godoc should start with symbol name \("TSingleFooBGI"\)`
+//
+// Deprecated:invalid deprecation
+//
+// Deprecated:invalid deprecation
+type TSingleFooBGI int
+
+type (
+	// Deprecated:invalid deprecation // want `godoc should start with symbol name \("TMultiFooBGI"\)`
+	//
+	// Deprecated:invalid deprecation
+	//
+	// bad godoc
+	TMultiFooBGI int
+
+	// Deprecated:invalid deprecation // want `godoc should start with symbol name \("TMultiBarBGI"\)`
+	//
+	// Deprecated:invalid deprecation
+	//
+	// bad godoc
+	TMultiBarBGI int
+)
+
+// Deprecated:invalid deprecation // want `godoc should start with symbol name \("FooFuncBGI"\)`
+//
+// bad godoc
+//
+// Deprecated:valid deprecation
+func FooFuncBGI() {}
+
+// This is not a valid deprecation:
+
+// Deprecated // want `godoc should start with symbol name \("TFooBGI"\)`
+type TFooBGI int
+
+// This is not a valid deprecation:
+
+// The //foo:bar directives mark the trailing comment as a directive so they're
+// not parsed as a normal trailing comment group.
+
+// Deprecated://foo:bar // want `godoc should start with symbol name \("FooFuncBGI"\)`
+func (*TFooBGI) FooFuncBGI() {}


### PR DESCRIPTION
Fixes #36

Skipping paragraphs starting with `// Deprecated:` is not as straightforward as it seems. This is explained in the code. To avoid a hacky and potentially wrong implementation, deprecated symbols/packages are now exempt from the `start-with-name` and `pkg-doc` rules.