### PR TITLE
Add specific-file-pkg-doc rule

### DIFF
--- a/.godoc-lint.default.yaml
+++ b/.godoc-lint.default.yaml
@@ -53,6 +53,7 @@ default: basic
 #   - pkg-doc
 #   - single-pkg-doc
 #   - require-pkg-doc
+#   - specific-file-pkg-doc
 #   - start-with-name
 #   - require-doc
 #   - deprecated
@@ -87,6 +88,19 @@ options:
 
   # Include test files when applying the `require-pkg-doc` rule.
   require-pkg-doc/include-tests: false
+
+  # Include test files when applying the `specific-file-pkg-doc` rule.
+  specific-file-pkg-doc/include-tests: false
+
+  # The file pattern to indicate which file should contain the package-level godoc when
+  # applying the `specific-file-pkg-doc` rule.
+  #
+  # Valid values are:
+  #
+  #   - "doc": The godoc should be in a file named doc.go
+  #   - "package-name": The godoc should be in a file named after the package. For example, if a package
+  #     is named "foobar", the godoc should be in a file named "foobar.go".
+  specific-file-pkg-doc/file-pattern: "doc"
 
   # Include test files when applying the `require-doc` rule.
   require-doc/include-tests: false

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ Technically, every Go file in a package can have a godoc above the `package` sta
 
 Ensures that every Go package has godoc(s). By default, test files (i.e., `*_test.go`) and therefore test packages (i.e., `*_test`) are ignored. To include them in the check, the `require-pkg-doc/include-tests` should be set to `true`.
 
+### `specific-file-pkg-doc`
+
+Ensures that if there is godoc for a given package, it must be in a specific file as determined by the `specific-file-pkg-doc/file-pattern` configuration value. The valid options:
+
+- `doc`: Package-level godoc must be in a file named "doc.go".
+- `package-name`: Package-level godoc must be in a file named after the package. For example, the package "foobar" must have its Godoc in a file named "foobar.go".
+
+By default, `doc` is used.
+
+Note that this does not enforce that godoc is present, this is the job of the `require-pkg-doc` rule. If `require-pkg-doc` is not enabled but `specigic-file-pkg-doc` is enabled, an error will not appear if there is no package-level godoc, but an error will still appear if package-level godoc is in the wrong location.
+
 ### `start-with-name`
 
 Checks godocs start with the corresponding symbol name:

--- a/pkg/config/default.yaml
+++ b/pkg/config/default.yaml
@@ -7,6 +7,8 @@ options:
   pkg-doc/include-tests: false
   single-pkg-doc/include-tests: false
   require-pkg-doc/include-tests: false
+  specific-file-pkg-doc/include-tests: false
+  specific-file-pkg-doc/file-pattern: "doc"
   require-doc/include-tests: false
   require-doc/ignore-exported: false
   require-doc/ignore-unexported: true

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -109,15 +109,17 @@ type Config interface {
 
 // RuleOptions represents individual linter rule configurations.
 type RuleOptions struct {
-	MaxLenLength                   uint `option:"max-len/length"`
-	MaxLenIncludeTests             bool `option:"max-len/include-tests"`
-	PkgDocIncludeTests             bool `option:"pkg-doc/include-tests"`
-	SinglePkgDocIncludeTests       bool `option:"single-pkg-doc/include-tests"`
-	RequirePkgDocIncludeTests      bool `option:"require-pkg-doc/include-tests"`
-	RequireDocIncludeTests         bool `option:"require-doc/include-tests"`
-	RequireDocIgnoreExported       bool `option:"require-doc/ignore-exported"`
-	RequireDocIgnoreUnexported     bool `option:"require-doc/ignore-unexported"`
-	StartWithNameIncludeTests      bool `option:"start-with-name/include-tests"`
-	StartWithNameIncludeUnexported bool `option:"start-with-name/include-unexported"`
-	NoUnusedLinkIncludeTests       bool `option:"no-unused-link/include-tests"`
+	MaxLenLength                   uint   `option:"max-len/length"`
+	MaxLenIncludeTests             bool   `option:"max-len/include-tests"`
+	PkgDocIncludeTests             bool   `option:"pkg-doc/include-tests"`
+	SinglePkgDocIncludeTests       bool   `option:"single-pkg-doc/include-tests"`
+	RequirePkgDocIncludeTests      bool   `option:"require-pkg-doc/include-tests"`
+	SpecificFilePkgDocIncludeTests bool   `option:"specific-file-pkg-doc/include-tests"`
+	SpecificFilePkgDocFilePattern  string `option:"specific-file-pkg-doc/file-pattern"`
+	RequireDocIncludeTests         bool   `option:"require-doc/include-tests"`
+	RequireDocIgnoreExported       bool   `option:"require-doc/ignore-exported"`
+	RequireDocIgnoreUnexported     bool   `option:"require-doc/ignore-unexported"`
+	StartWithNameIncludeTests      bool   `option:"start-with-name/include-tests"`
+	StartWithNameIncludeUnexported bool   `option:"start-with-name/include-unexported"`
+	NoUnusedLinkIncludeTests       bool   `option:"no-unused-link/include-tests"`
 }

--- a/pkg/model/rule.go
+++ b/pkg/model/rule.go
@@ -10,6 +10,8 @@ const (
 	SinglePkgDocRule Rule = "single-pkg-doc"
 	// RequirePkgDocRule represents the "require-pkg-doc" rule.
 	RequirePkgDocRule Rule = "require-pkg-doc"
+	// SpecificFilePkgDocRule represents the "specific-file-pkg-doc" rule.
+	SpecificFilePkgDocRule Rule = "specific-file-pkg-doc"
 	// StartWithNameRule represents the "start-with-name" rule.
 	StartWithNameRule Rule = "start-with-name"
 	// RequireDocRule represents the "require-doc" rule.
@@ -28,6 +30,7 @@ var AllRules = func() RuleSet {
 		PkgDocRule,
 		SinglePkgDocRule,
 		RequirePkgDocRule,
+		SpecificFilePkgDocRule,
 		StartWithNameRule,
 		RequireDocRule,
 		DeprecatedRule,

--- a/testdata/rule/specific_file_pkg_doc/good/.godoc-lint.yaml
+++ b/testdata/rule/specific_file_pkg_doc/good/.godoc-lint.yaml
@@ -1,0 +1,6 @@
+default: none
+enable:
+  - specific-file-pkg-doc
+options:
+  specific-file-pkg-doc/include-tests: false
+  specific-file-pkg-doc/file-pattern: doc

--- a/testdata/rule/specific_file_pkg_doc/good/doc.go
+++ b/testdata/rule/specific_file_pkg_doc/good/doc.go
@@ -1,0 +1,4 @@
+// some header
+
+// this package has a single godoc in doc.go.
+package good

--- a/testdata/rule/specific_file_pkg_doc/good/with_godoc_pkg_test.go
+++ b/testdata/rule/specific_file_pkg_doc/good/with_godoc_pkg_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this package has a single godoc.
+package good_test

--- a/testdata/rule/specific_file_pkg_doc/good/with_godoc_test.go
+++ b/testdata/rule/specific_file_pkg_doc/good/with_godoc_test.go
@@ -1,0 +1,5 @@
+// some header
+
+// this package has a repeated godoc in this test file, but it's not included
+// in the check.
+package good

--- a/testdata/rule/specific_file_pkg_doc/good/without_godoc.go
+++ b/testdata/rule/specific_file_pkg_doc/good/without_godoc.go
@@ -1,0 +1,3 @@
+// some header
+
+package good

--- a/testdata/rule/specific_file_pkg_doc/good/without_godoc_pkg_test.go
+++ b/testdata/rule/specific_file_pkg_doc/good/without_godoc_pkg_test.go
@@ -1,0 +1,3 @@
+// some header
+
+package good_test

--- a/testdata/rule/specific_file_pkg_doc/good_disabled/.godoc-lint.yaml
+++ b/testdata/rule/specific_file_pkg_doc/good_disabled/.godoc-lint.yaml
@@ -1,0 +1,6 @@
+default: none
+enable:
+  - specific-file-pkg-doc
+options:
+  specific-file-pkg-doc/include-tests: false
+  specific-file-pkg-doc/file-pattern: doc

--- a/testdata/rule/specific_file_pkg_doc/good_disabled/doc.go
+++ b/testdata/rule/specific_file_pkg_doc/good_disabled/doc.go
@@ -1,0 +1,4 @@
+// some header
+
+// this package has a single godoc in doc.go.
+package good_disabled

--- a/testdata/rule/specific_file_pkg_doc/good_disabled/with_godoc_and_disable.go
+++ b/testdata/rule/specific_file_pkg_doc/good_disabled/with_godoc_and_disable.go
@@ -1,0 +1,6 @@
+// some header
+
+// this is another godoc for this package but the rule is disabled.
+//
+//godoclint:disable specific-file-pkg-doc
+package good_disabled

--- a/testdata/rule/specific_file_pkg_doc/good_disabled/without_godoc_with_directive.go
+++ b/testdata/rule/specific_file_pkg_doc/good_disabled/without_godoc_with_directive.go
@@ -1,0 +1,4 @@
+// some header
+
+//foo:bar
+package good_disabled

--- a/testdata/rule/specific_file_pkg_doc/good_include_tests/.godoc-lint.yaml
+++ b/testdata/rule/specific_file_pkg_doc/good_include_tests/.godoc-lint.yaml
@@ -1,0 +1,6 @@
+default: none
+enable:
+  - specific-file-pkg-doc
+options:
+  specific-file-pkg-doc/include-tests: true
+  specific-file-pkg-doc/file-pattern: package-name

--- a/testdata/rule/specific_file_pkg_doc/good_include_tests/good.go
+++ b/testdata/rule/specific_file_pkg_doc/good_include_tests/good.go
@@ -1,0 +1,4 @@
+// some header
+
+// this package has a single godoc in good.go.
+package good

--- a/testdata/rule/specific_file_pkg_doc/good_include_tests/good_test.go
+++ b/testdata/rule/specific_file_pkg_doc/good_include_tests/good_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this package has a single godoc.
+package good_test

--- a/testdata/rule/specific_file_pkg_doc/good_include_tests/without_godoc.go
+++ b/testdata/rule/specific_file_pkg_doc/good_include_tests/without_godoc.go
@@ -1,0 +1,3 @@
+// some header
+
+package good

--- a/testdata/rule/specific_file_pkg_doc/good_include_tests/without_godoc_pkg_test.go
+++ b/testdata/rule/specific_file_pkg_doc/good_include_tests/without_godoc_pkg_test.go
@@ -1,0 +1,3 @@
+// some header
+
+package good_test

--- a/testdata/rule/specific_file_pkg_doc/good_include_tests/without_godoc_test.go
+++ b/testdata/rule/specific_file_pkg_doc/good_include_tests/without_godoc_test.go
@@ -1,0 +1,3 @@
+// some header
+
+package good

--- a/testdata/rule/specific_file_pkg_doc/multiple/.godoc-lint.yaml
+++ b/testdata/rule/specific_file_pkg_doc/multiple/.godoc-lint.yaml
@@ -1,0 +1,6 @@
+default: none
+enable:
+  - specific-file-pkg-doc
+options:
+  specific-file-pkg-doc/include-tests: false
+  specific-file-pkg-doc/file-pattern: package-name

--- a/testdata/rule/specific_file_pkg_doc/multiple/file_one_pkg_test.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple/file_one_pkg_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc but it's ignored since this is a test file.
+package multiple_test

--- a/testdata/rule/specific_file_pkg_doc/multiple/file_one_test.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple/file_one_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc but it's ignored since this is a test file.
+package multiple

--- a/testdata/rule/specific_file_pkg_doc/multiple/file_two.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple/file_two.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc. // want `package-level godoc must be in file named "multiple.go" but was in "file_two.go"`
+package multiple

--- a/testdata/rule/specific_file_pkg_doc/multiple/file_two_pkg_test.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple/file_two_pkg_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc but it's ignored since this is a test file.
+package multiple_test

--- a/testdata/rule/specific_file_pkg_doc/multiple/file_two_test.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple/file_two_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc but it's ignored since this is a test file.
+package multiple

--- a/testdata/rule/specific_file_pkg_doc/multiple/multiple.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple/multiple.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc.
+package multiple

--- a/testdata/rule/specific_file_pkg_doc/multiple_include_tests/.godoc-lint.yaml
+++ b/testdata/rule/specific_file_pkg_doc/multiple_include_tests/.godoc-lint.yaml
@@ -1,0 +1,6 @@
+default: none
+enable:
+  - specific-file-pkg-doc
+options:
+  specific-file-pkg-doc/include-tests: true
+  specific-file-pkg-doc/file-pattern: doc

--- a/testdata/rule/specific_file_pkg_doc/multiple_include_tests/doc.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple_include_tests/doc.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc.
+package multiple

--- a/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_one_pkg_test.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_one_pkg_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc. // want `package-level godoc must be in file named "doc.go" but was in "file_one_pkg_test.go"`
+package multiple_test

--- a/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_one_test.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_one_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc. // want `package-level godoc must be in file named "doc.go" but was in "file_one_test.go"`
+package multiple

--- a/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_two.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_two.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc. // want `package-level godoc must be in file named "doc.go" but was in "file_two.go"`
+package multiple

--- a/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_two_pkg_test.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_two_pkg_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc. // want `package-level godoc must be in file named "doc.go" but was in "file_two_pkg_test.go"`
+package multiple_test

--- a/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_two_test.go
+++ b/testdata/rule/specific_file_pkg_doc/multiple_include_tests/file_two_test.go
@@ -1,0 +1,4 @@
+// some header
+
+// this is a godoc. // want `package-level godoc must be in file named "doc.go" but was in "file_two_test.go"`
+package multiple


### PR DESCRIPTION
This PR adds a new `specific-file-pkg-doc` rule. This rule verifies that if package-level godoc is present, this godoc is in a specific file.

Enforcing that godoc is within a specific file is something we want to do at our organization regularly - when browsing source code, it's nice to know exactly which file will contain the godoc for the package.

This PR provides two options of file patterns that can be checked via the `specific-file-pkg-doc/file-pattern` configuration value:

- `doc` (default): Package-level Godoc must be in a file named `doc.go`.
- `package-name`: Package-level Godoc must be in a file named after the package. For example, a package `foobar` must have its Godoc in a file named `foobar.go`.

I've attempted to follow repository convention as closely as possible, but may have missed some things.