### PR TITLE
ci: enable linters that modernizes code a bit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,10 @@ linters:
   enable:
     - godoclint
     - godot
+    - intrange
+    - modernize
     - testifylint
+    - unconvert
   settings:
     godoclint:
       default: all

--- a/cmd/godoclint/main.go
+++ b/cmd/godoclint/main.go
@@ -61,8 +61,7 @@ func main() {
 
 	walkNonEmptyCSV := func(f func(string) error) func(string) error {
 		return func(value string) error {
-			values := strings.Split(strings.TrimSpace(value), ",")
-			for _, v := range values {
+			for v := range strings.SplitSeq(strings.TrimSpace(value), ",") {
 				if strings.TrimSpace(v) == "" {
 					return errors.New("empty element")
 				}

--- a/pkg/config/default_test.go
+++ b/pkg/config/default_test.go
@@ -21,8 +21,8 @@ func TestDefaultConfigYAMLIsValid(t *testing.T) {
 	visitedOptions := map[string]struct{}{}
 
 	v := reflect.ValueOf(*def.Options)
-	vt := reflect.TypeOf(*def.Options)
-	for i := 0; i < vt.NumField(); i++ {
+	vt := reflect.TypeFor[config.PlainRuleOptions]()
+	for i := range vt.NumField() {
 		ft := vt.Field(i)
 
 		require.Equal(reflect.Pointer, ft.Type.Kind(), `field type should be a pointer type for %q`, ft.Name)

--- a/pkg/config/plain.go
+++ b/pkg/config/plain.go
@@ -43,7 +43,7 @@ func transferOptions(target *model.RuleOptions, source *PlainRuleOptions) {
 	resVT := resV.Type()
 
 	resOptionMap := make(map[string]string, resVT.NumField())
-	for i := 0; i < resVT.NumField(); i++ {
+	for i := range resVT.NumField() {
 		ft := resVT.Field(i)
 		key, ok := ft.Tag.Lookup("option")
 		if !ok {
@@ -54,7 +54,7 @@ func transferOptions(target *model.RuleOptions, source *PlainRuleOptions) {
 
 	v := reflect.ValueOf(source).Elem()
 	vt := v.Type()
-	for i := 0; i < vt.NumField(); i++ {
+	for i := range vt.NumField() {
 		ft := vt.Field(i)
 		key, ok := ft.Tag.Lookup("option")
 		if !ok {

--- a/pkg/inspect/inspector.go
+++ b/pkg/inspect/inspector.go
@@ -296,14 +296,13 @@ func (i *Inspector) extractCommentGroup(cg *ast.CommentGroup) *model.CommentGrou
 func extractDisableDirectivesInComment(s string) model.InspectorResultDisableRules {
 	result := model.InspectorResultDisableRules{}
 	for _, directive := range disableDirectivePattern.FindAllStringSubmatch(s, -1) {
-		args := string(directive[1])
+		args := directive[1]
 		if args == "" {
 			result.All = true
 			continue
 		}
 
-		names := strings.Split(strings.TrimSpace(args), " ")
-		for _, name := range names {
+		for name := range strings.SplitSeq(strings.TrimSpace(args), " ") {
 			if model.AllRules.Has(model.Rule(name)) {
 				result.Rules = result.Rules.Add(model.Rule(name))
 			}


### PR DESCRIPTION
This PR enables the following linters:

- [modernize](https://golangci-lint.run/docs/linters/configuration/#modernize)
- [intrange](https://golangci-lint.run/docs/linters/configuration/#intrange)
- [unconvert](https://golangci-lint.run/docs/linters/configuration/#unconvert)

```console
❯ golangci-lint run
pkg/config/default_test.go:25:2: for loop can be changed to use an integer range (Go 1.22+)
Because the key is returned by a function or method, take care to consider side effects. (intrange)
        for i := 0; i < vt.NumField(); i++ {
        ^
pkg/config/plain.go:46:2: for loop can be changed to use an integer range (Go 1.22+)
Because the key is returned by a function or method, take care to consider side effects. (intrange)
        for i := 0; i < resVT.NumField(); i++ {
        ^
pkg/config/plain.go:57:2: for loop can be changed to use an integer range (Go 1.22+)
Because the key is returned by a function or method, take care to consider side effects. (intrange)
        for i := 0; i < vt.NumField(); i++ {
        ^
cmd/godoclint/main.go:64:14: stringsseq: Ranging over SplitSeq is more efficient (modernize)
                        values := strings.Split(strings.TrimSpace(value), ",")
                                  ^
pkg/config/default_test.go:24:8: reflecttypefor: reflect.TypeOf call can be simplified using TypeFor (modernize)
        vt := reflect.TypeOf(*def.Options)
              ^
pkg/inspect/inspector.go:305:12: stringsseq: Ranging over SplitSeq is more efficient (modernize)
                names := strings.Split(strings.TrimSpace(args), " ")
                         ^
pkg/inspect/inspector.go:299:17: unnecessary conversion (unconvert)
                args := string(directive[1])
                              ^
7 issues:
* intrange: 3
* modernize: 3
* unconvert: 1
```